### PR TITLE
Pass `mergeAttrs: true` by default.

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,5 +67,5 @@ In lieu of a formal styleguide, take care to maintain the existing coding style.
 [MIT License](LICENSE-MIT)
 
 ## Release History
-* 2013-07-02    v0.1.2    Add support YAML. Added XML to JSON/YAML, JSON toYAML, and YAML to JSON.
+* 2013-07-15    v0.1.2    Add support YAML. Added XML to JSON/YAML, JSON toYAML, and YAML to JSON.
 * 2013-07-02    v0.1.1    XML to JSON.

--- a/tasks/convert.js
+++ b/tasks/convert.js
@@ -18,6 +18,7 @@ module.exports = function(grunt) {
 
     // Merge task-specific and/or target-specific options with these defaults.
     var options = this.options({
+      mergeAttrs: true,
       inline: 2,
       indent: 2
     });
@@ -54,7 +55,7 @@ module.exports = function(grunt) {
 
       // Convert to json type
       if (srcType === 'xml') {
-        parse(srcFiles, function(err, result) {
+        parse(srcFiles, options, function(err, result) {
           data = JSON.stringify(result, null, options.indent);
         });
       } else if (srcType === 'yml') {


### PR DESCRIPTION
Merge attributes and child elements as properties of the parent, instead
of keying attributes off a child attribute object.
