### PR TITLE
Removing duplicated 'convert'

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -142,7 +142,7 @@ module.exports = function(grunt) {
   grunt.registerTask('test', ['jshint', 'convert']);
 
   // By default, lint and run all tests.
-  grunt.registerTask('default', ['clean', 'test', 'convert']);
+  grunt.registerTask('default', ['clean', 'test']);
 
 
 };


### PR DESCRIPTION
`'convert'` was specified in the `'default'` and `'test'` tasks, while
`'test'` was being called from within `'default'` causing `'convert'`
to be run twice.
