### PR TITLE
Update convert.js

### DIFF
--- a/tasks/convert.js
+++ b/tasks/convert.js
@@ -90,6 +90,9 @@
         handled = true;
         var parse = require('xml2js').parseString;
         parse(srcFiles, options, function(err, result) {
+          if (err) {
+            grunt.fail.warn('File ' + f.dest.cyan + ' parsing errors: ' + err);
+          }
           data = JSON.stringify(result, null, options.indent);
           grunt.file.write(f.dest, data);
           finish();


### PR DESCRIPTION
In case of XML parsing error, display a warning and abort Grunt immediately (unless --force was specified). Disabling strict option for parsing can help.
