### PR TITLE
feat(yaml): catch yaml parse error

### DIFF
--- a/tasks/convert.js
+++ b/tasks/convert.js
@@ -101,7 +101,12 @@
 
       } else if (srcExt === '.yml' || srcExt === '.yaml') {
 
-        data = JSON.stringify(YAML.load(f.src[0]), null, options.indent);
+        try {
+          data = JSON.stringify(YAML.load(f.src[0]), null, options.indent);
+        }
+        catch (e) {
+          grunt.fail.warn('File ' + f.dest.cyan + ' parsing error: ' + e.message);
+        }
 
       } else if (srcExt === '.plist') {
 


### PR DESCRIPTION
Avoid grunt being silent about a parse error.
